### PR TITLE
Updated Makefile for dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,28 @@ sonar:
 sonar-pr-analysis:
 	mvn sonar:sonar	-P sonar-pr-analysis
 
+.PHONY: dependency-check
+dependency-check:
+	@ if [ -n "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
+		if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
+			suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
+		else \
+			printf -- 'DEPENDENCY_CHECK_SUPPRESSIONS_HOME is set, but its value "%s" does not point to a directory\n' "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)"; \
+			exit 1; \
+		fi; \
+	fi; \
+	if [ ! -d "$${suppressions_home}" ]; then \
+		suppressions_home_target_dir="./target/dependency-check-suppressions"; \
+		if [ -d "$${suppressions_home_target_dir}" ]; then \
+			suppressions_home="$${suppressions_home_target_dir}"; \
+		else \
+			mkdir -p "./target"; \
+			git clone git@github.com:companieshouse/dependency-check-suppressions.git "$${suppressions_home_target_dir}" && \
+				suppressions_home="$${suppressions_home_target_dir}"; \
+		fi; \
+	fi; \
+	printf -- 'suppressions_home="%s"\n' "$${suppressions_home}"; \
+	DEPENDENCY_CHECK_SUPPRESSIONS_HOME="$${suppressions_home}" "$${suppressions_home}/scripts/depcheck" --repo-name=notification-letter-producer
+
+.PHONY: security-check
+security-check: dependency-check

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 artifact_name       := notification-letter-producer
 version := "unversioned"
 
+dependency_check_runner := 416670754337.dkr.ecr.eu-west-2.amazonaws.com/dependency-check-runner
+
 .PHONY: all
 all: build
 
@@ -44,26 +46,7 @@ sonar-pr-analysis:
 
 .PHONY: dependency-check
 dependency-check:
-	@ if [ -n "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
-		if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
-			suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
-		else \
-			printf -- 'DEPENDENCY_CHECK_SUPPRESSIONS_HOME is set, but its value "%s" does not point to a directory\n' "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)"; \
-			exit 1; \
-		fi; \
-	fi; \
-	if [ ! -d "$${suppressions_home}" ]; then \
-		suppressions_home_target_dir="./target/dependency-check-suppressions"; \
-		if [ -d "$${suppressions_home_target_dir}" ]; then \
-			suppressions_home="$${suppressions_home_target_dir}"; \
-		else \
-			mkdir -p "./target"; \
-			git clone git@github.com:companieshouse/dependency-check-suppressions.git "$${suppressions_home_target_dir}" && \
-				suppressions_home="$${suppressions_home_target_dir}"; \
-		fi; \
-	fi; \
-	printf -- 'suppressions_home="%s"\n' "$${suppressions_home}"; \
-	DEPENDENCY_CHECK_SUPPRESSIONS_HOME="$${suppressions_home}" "$${suppressions_home}/scripts/depcheck" --repo-name=notification-letter-producer
+	docker run --rm -e DEPENDENCY_CHECK_SUPPRESSIONS_HOME=/opt -v "$$(pwd)":/app -w /app ${dependency_check_runner} --repo-name="$(basename "$$(pwd)")"
 
 .PHONY: security-check
 security-check: dependency-check

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 artifact_name       := notification-letter-producer
 version := "unversioned"
 
-dependency_check_runner := 416670754337.dkr.ecr.eu-west-2.amazonaws.com/dependency-check-runner
-
 .PHONY: all
 all: build
 
@@ -43,10 +41,3 @@ sonar:
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	mvn sonar:sonar	-P sonar-pr-analysis
-
-.PHONY: dependency-check
-dependency-check:
-	docker run --rm -e DEPENDENCY_CHECK_SUPPRESSIONS_HOME=/opt -v "$$(pwd)":/app -w /app ${dependency_check_runner} --repo-name="$(basename "$$(pwd)")"
-
-.PHONY: security-check
-security-check: dependency-check

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.11</version>
+        <version>2.1.12</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,10 @@
     <name>Notification Letter/Email Producer</name>
 
     <parent>
-        <artifactId>companies-house-parent</artifactId>
         <groupId>uk.gov.companieshouse</groupId>
-        <version>1.2.0</version>
+        <artifactId>companies-house-parent</artifactId>
+        <version>2.1.11</version>
+        <relativePath/>
     </parent>
 
     <properties>


### PR DESCRIPTION
Updated parent pom to 2.1.11, use relativePath 2.1.11 brings in latest correct dependency-check settings.
Updated Makefile to roll over to latest version of dependency-check feature for centralized vulnerability scanning.